### PR TITLE
Add in newer networking api versions

### DIFF
--- a/lib/puppet_x/puppetlabs/kubernetes/provider.rb
+++ b/lib/puppet_x/puppetlabs/kubernetes/provider.rb
@@ -131,6 +131,10 @@ module PuppetX
             beta_client.send(method, *object)
           elsif storage_client.respond_to?(method)
             storage_client.send(method, *object)
+          elsif network_v1_client.respond_to?(method)
+            network_v1_client.send(method, *object)
+          elsif network_beta_client.respond_to?(method)
+            network_beta_client.send(method, *object)
           elsif policy_client.respond_to?(method)
             policy_client.send(method, *object)
           else

--- a/lib/puppet_x/puppetlabs/kubernetes/provider.rb
+++ b/lib/puppet_x/puppetlabs/kubernetes/provider.rb
@@ -81,6 +81,26 @@ module PuppetX
           add_headers(client)
         end
 
+        def self.network_v1_client
+          client = ::Kubeclient::Client.new(
+            "#{config.context.api_endpoint}/apis/networking.k8s.io",
+            config.context.api_version,
+            ssl_options: config.context.ssl_options,
+            auth_options: config.context.auth_options,
+          )
+          add_headers(client)
+        end
+
+        def self.network_beta_client
+          client = ::Kubeclient::Client.new(
+            "#{config.context.api_endpoint}/apis/networking.k8s.io",
+            "#{config.context.api_version}beta1",
+            ssl_options: config.context.ssl_options,
+            auth_options: config.context.auth_options,
+          )
+          add_headers(client)
+        end
+
         def self.policy_client
           client = ::Kubeclient::Client.new(
             "#{config.context.api_endpoint}/apis/policy",


### PR DESCRIPTION
This adds missing resources to replace the `extensions` apiVersion, which is removed in later versions of kubernetes (1.16+). This has been tested in a 1.16.8 test cluster.